### PR TITLE
Add dynamic podcast topics and improve topic handling

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import "./HomePage.css";
+import { fetchAvailablePodcastTopics } from "../services/perplexity";
 
 interface AudioEffect {
   id: number;
@@ -15,6 +16,16 @@ const HomePage: React.FC = () => {
   const [audioEffects, setAudioEffects] = useState<AudioEffect[]>([]);
   const [effectId, setEffectId] = useState(0);
   const animationRef = useRef<number | undefined>(undefined);
+  const [podcastTopics, setPodcastTopics] = useState<{ topic: string, duration: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchAvailablePodcastTopics()
+      .then(setPodcastTopics)
+      .catch(() => setError("Failed to load podcast topics."))
+      .finally(() => setLoading(false));
+  }, []);
 
   useEffect(() => {
     const createRandomEffect = () => {
@@ -135,29 +146,28 @@ const HomePage: React.FC = () => {
           />
         )
       ))}
-      
       <header className="harkai-banner">
         <h1>Hark-AI</h1>
       </header>
-      
       <section className="homepage-content">
         <h2 className="homepage-title">Welcome to Hark-AI</h2>
         <p className="homepage-subtitle">Choose your podcast experience</p>
-        
         <div className="button-container">
-          <button 
-            className="podcast-button daily-podcast"
-            onClick={handleDailyPodcast}
-          >
-            Daily Podcast
-          </button>
-          
-          <button 
-            className="podcast-button ankylosing-spondylitis"
-            onClick={handleAnkylosingSpondylitis}
-          >
-            Ankylosing Spondylitis
-          </button>
+          {loading && <p>Loading topics...</p>}
+          {error && <p style={{ color: 'red' }}>{error}</p>}
+          {!loading && !error && podcastTopics.map(({ topic, duration }) => {
+            // Convert underscores to %s for URL
+            const linkTopic = topic.replace(/_/g, '%s');
+            return (
+              <button
+                key={topic}
+                className="podcast-button"
+                onClick={() => navigate(`/podcasts/?topic=${encodeURIComponent(linkTopic)}&dur=${encodeURIComponent(duration)}`)}
+              >
+                {topic.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
+              </button>
+            );
+          })}
         </div>
       </section>
     </div>

--- a/src/services/perplexity.ts
+++ b/src/services/perplexity.ts
@@ -69,6 +69,18 @@ export async function fetchDailyNewsPodcast(): Promise<string> {
 }
 
 /**
+ * Fetches available podcast topics from the backend
+ * @returns A promise resolving to an array of topics
+ */
+export async function fetchAvailablePodcastTopics(): Promise<{ topic: string, duration: string }[]> {
+  const response = await fetch('/api/podcast-topics');
+  if (!response.ok) {
+    throw new Error('Failed to fetch podcast topics');
+  }
+  return response.json();
+}
+
+/**
  * Check if the Perplexity API key is configured
  */
 export function isPerplexityConfigured(): boolean {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://127.0.0.1:8787'
+    }
+  },
 })


### PR DESCRIPTION
HomePage now fetches available podcast topics from the backend and displays them as buttons, replacing hardcoded options. PodcastPage refactored to handle dynamic topics, improve title formatting, and add logging for podcast search. Added fetchAvailablePodcastTopics service and configured Vite proxy for API requests.