### PR TITLE
Add Topic Page and Use GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Audio Player Demo
+# Hark AI Front End
 
 A simple web application built with React and Vite that features a button to play and pause an audio file.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage';
 import PodcastPage from './components/PodcastPage';
+import TopicPage from './components/TopicPage';
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/topics/:topic" element={<TopicPage />} />
         <Route path="/podcasts/" element={<PodcastPage />} />
       </Routes>
     </Router>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -16,7 +16,7 @@ const HomePage: React.FC = () => {
   const [audioEffects, setAudioEffects] = useState<AudioEffect[]>([]);
   const [effectId, setEffectId] = useState(0);
   const animationRef = useRef<number | undefined>(undefined);
-  const [podcastTopics, setPodcastTopics] = useState<{ topic: string, duration: string }[]>([]);
+  const [podcastTopics, setPodcastTopics] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -147,14 +147,12 @@ const HomePage: React.FC = () => {
         <div className="button-container">
           {loading && <p>Loading topics...</p>}
           {error && <p style={{ color: 'red' }}>{error}</p>}
-          {!loading && !error && podcastTopics.map(({ topic, duration }) => {
-            // Convert underscores to %s for URL
-            const linkTopic = topic.replace(/_/g, '%s');
+          {!loading && !error && podcastTopics.map((topic) => {
             return (
               <button
                 key={topic}
                 className="podcast-button"
-                onClick={() => navigate(`/podcasts/?topic=${encodeURIComponent(linkTopic)}&dur=${encodeURIComponent(duration)}`)}
+                onClick={() => navigate(`/topics/${encodeURIComponent(topic)}`)}
               >
                 {topic.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
               </button>

--- a/src/components/PodcastPage.tsx
+++ b/src/components/PodcastPage.tsx
@@ -108,6 +108,20 @@ const PodcastPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    const audioUrl = searchParams.get('audioUrl');
+    const title = searchParams.get('title');
+    
+    // If audioUrl is provided (from TopicPage), use it directly
+    if (audioUrl) {
+      setIsLoading(true);
+      setError(null);
+      setAudioUrl(audioUrl);
+      setPodcastTitle(title || "Podcast");
+      setIsLoading(false);
+      return;
+    }
+    
+    // Otherwise, use the existing R2 search logic
     const topic = searchParams.get('topic') || 'daily';
     const dur = searchParams.get('dur') || '5';
     

--- a/src/components/TopicPage.css
+++ b/src/components/TopicPage.css
@@ -1,0 +1,133 @@
+.topic-content {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 24px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  position: relative;
+  z-index: 2;
+}
+
+.topic-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
+  color: #667eea;
+  letter-spacing: 0.04em;
+  text-align: center;
+}
+
+.podcast-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.podcast-item {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 1.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid rgba(102, 126, 234, 0.2);
+}
+
+.podcast-item:hover {
+  background: rgba(102, 126, 234, 0.15);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(102, 126, 234, 0.2);
+  border-color: rgba(102, 126, 234, 0.4);
+}
+
+.podcast-item-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+  color: #667eea;
+}
+
+.podcast-item-date {
+  font-size: 0.9rem;
+  color: #c7ecee;
+  margin: 0 0 0.75rem 0;
+  opacity: 0.8;
+  font-style: italic;
+}
+
+.podcast-item-summary {
+  font-size: 1rem;
+  color: #f5f6fa;
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.9;
+}
+
+.no-podcasts {
+  text-align: center;
+  padding: 3rem;
+  color: #c7ecee;
+  font-style: italic;
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem;
+}
+
+.loading-spinner {
+  border: 4px solid rgba(102, 126, 234, 0.1);
+  border-left: 4px solid #667eea;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1rem;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.error-message {
+  background: rgba(255, 107, 107, 0.1);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin: 2rem auto;
+  text-align: center;
+}
+
+.error-message h4 {
+  color: #ff6b6b;
+  margin: 0 0 0.5rem 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.error-message p {
+  color: #f5f6fa;
+  margin: 0;
+  opacity: 0.9;
+}
+
+@media (max-width: 700px) {
+  .topic-content {
+    margin: 1rem;
+    padding: 1.5rem;
+  }
+  
+  .topic-title {
+    font-size: 1.5rem;
+  }
+  
+  .podcast-item {
+    padding: 1rem;
+  }
+  
+  .podcast-item-title {
+    font-size: 1.1rem;
+  }
+}
+

--- a/src/components/TopicPage.tsx
+++ b/src/components/TopicPage.tsx
@@ -1,0 +1,216 @@
+import React, { useEffect, useState, useRef } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import "./TopicPage.css";
+import { fetchPodcastsForTopic, fetchPresignedUrl, Podcast } from "../services/backend";
+
+interface AudioEffect {
+  id: number;
+  type: 'wave' | 'bit';
+  y: number;
+  delay: number;
+  startTime: number;
+}
+
+const TopicPage: React.FC = () => {
+  const { topic } = useParams<{ topic: string }>();
+  const navigate = useNavigate();
+  const [podcasts, setPodcasts] = useState<Podcast[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [audioEffects, setAudioEffects] = useState<AudioEffect[]>([]);
+  const [effectId, setEffectId] = useState(0);
+  const animationRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!topic) {
+      setError("Topic not specified");
+      setLoading(false);
+      return;
+    }
+
+    fetchPodcastsForTopic(topic)
+      .then(setPodcasts)
+      .catch(() => setError("Failed to load podcasts."))
+      .finally(() => setLoading(false));
+  }, [topic]);
+
+  useEffect(() => {
+    const animateParticles = () => {
+      setAudioEffects(prev => {
+        const now = Date.now();
+        return prev.filter(effect => {
+          const duration = effect.type === 'wave' ? 2500 : 1500;
+          const elapsed = now - effect.startTime;
+          const progress = Math.min(elapsed / duration, 2.5);
+          const distanceFromCenter = Math.abs(progress - 0.5) * 2;
+          const size = Math.max(0.1, 1 - distanceFromCenter * distanceFromCenter);
+          return !(progress >= 2.5 && size < 0.2);
+        });
+      });
+      animationRef.current = requestAnimationFrame(animateParticles);
+    };
+
+    animationRef.current = requestAnimationFrame(animateParticles);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const createRandomEffect = () => {
+      const type = Math.random() > 0.5 ? 'wave' : 'bit';
+      const y = Math.random() * window.innerHeight;
+      const delay = 4;
+      
+      const newEffect: AudioEffect = {
+        id: effectId,
+        type,
+        y,
+        delay,
+        startTime: Date.now()
+      };
+      
+      setAudioEffects(prev => [...prev, newEffect]);
+      setEffectId(prev => prev + 1);
+    };
+
+    const interval = setInterval(createRandomEffect, 3000);
+    const initialTimeout = setTimeout(createRandomEffect, 1000);
+
+    return () => {
+      clearInterval(interval);
+      clearTimeout(initialTimeout);
+    };
+  }, [effectId]);
+
+  const getParticleStyle = (effect: AudioEffect) => {
+    const now = Date.now();
+    const elapsed = now - effect.startTime;
+    const duration = effect.type === 'wave' ? 2500 : 1500;
+    const progress = Math.min(elapsed / duration, 1.5);
+    
+    const x = progress * (window.innerWidth + 50);
+    const distanceFromCenter = Math.abs(progress - 0.5) * 2;
+    const size = Math.max(0.1, 1 - distanceFromCenter * distanceFromCenter);
+    const yOffset = effect.type === 'bit' ? Math.sin(progress * Math.PI) * -30 : 0;
+    const opacity = (progress > 1.5 && size < 0.2) ? 0 : 1;
+    
+    return {
+      transform: `translateX(${x}px) translateY(${yOffset}px) scale(${size})`,
+      opacity: opacity,
+      top: `${effect.y}px`,
+      animationDelay: `${effect.delay}s`
+    };
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', { 
+      weekday: 'long', 
+      year: 'numeric', 
+      month: 'long', 
+      day: 'numeric' 
+    });
+  };
+
+  const handlePodcastClick = async (podcast: Podcast) => {
+    try {
+      const presignedUrl = await fetchPresignedUrl(podcast.id);
+      navigate(`/podcasts/?audioUrl=${encodeURIComponent(presignedUrl)}&title=${encodeURIComponent(podcast.title)}`);
+    } catch (err) {
+      setError(`Failed to load podcast: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
+
+  const formatTopicName = (topicName: string) => {
+    return topicName.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  };
+
+  return (
+    <div className="harkai-main">
+      {/* Audio wave background effects */}
+      {audioEffects.map(effect => (
+        effect.type === 'wave' ? (
+          <svg
+            key={effect.id}
+            className="audio-wave-svg"
+            width="60" height="60" viewBox="0 0 60 60"
+            style={getParticleStyle(effect)}
+          >
+            <path
+              d="M10 30 A 20 20 0 0 1 10 70"
+              fill="none"
+              stroke="rgba(0,198,255,0.5)"
+              strokeWidth="4"
+              strokeLinecap="round"
+            />
+          </svg>
+        ) : (
+          <div
+            key={effect.id}
+            className="audio-bit"
+            style={getParticleStyle(effect)}
+          />
+        )
+      ))}
+      
+      <header className="harkai-banner">
+        <h1>Hark-AI</h1>
+        <button 
+          className="back-button"
+          onClick={() => navigate('/')}
+        >
+          ← Home
+        </button>
+      </header>
+      
+      <section className="topic-content">
+        <h2 className="topic-title">{topic ? formatTopicName(topic) : 'Topic'}</h2>
+        
+        {loading && (
+          <div className="loading">
+            <div className="loading-spinner"></div>
+            <p>Loading podcasts...</p>
+          </div>
+        )}
+        
+        {error && (
+          <div className="error-message">
+            <h4>Error</h4>
+            <p>{error}</p>
+          </div>
+        )}
+        
+        {!loading && !error && podcasts.length === 0 && (
+          <div className="no-podcasts">
+            <p>No podcasts available for this topic yet.</p>
+          </div>
+        )}
+        
+        {!loading && !error && podcasts.length > 0 && (
+          <div className="podcast-list">
+            {podcasts.map((podcast) => (
+              <div
+                key={podcast.id}
+                className="podcast-item"
+                onClick={() => handlePodcastClick(podcast)}
+              >
+                <h3 className="podcast-item-title">{podcast.title}</h3>
+                <p className="podcast-item-date">{formatDate(podcast.created_at)}</p>
+                {podcast.summary && (
+                  <p className="podcast-item-summary">{podcast.summary}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default TopicPage;
+

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -1,31 +1,57 @@
 export type AvailablePodcast = { topic: string; duration: string };
 
 interface ViteImportMetaEnv {
-  VITE_WORKER_URL?: string;
+  VITE_GCP_FUNCTION_URL?: string;
 }
 
-function getWorkerBaseUrl(): string {
+function getGcpGatewayUrl(): string {
   // Prefer explicit env var if provided
-  const envUrl = (import.meta.env as unknown as ViteImportMetaEnv)?.VITE_WORKER_URL;
+  const envUrl = (import.meta.env as unknown as ViteImportMetaEnv)?.VITE_GCP_FUNCTION_URL;
   if (envUrl) return envUrl;
 
-  // Auto-detect local vs production
-  if (typeof window !== 'undefined') {
-    const host = window.location.hostname;
-    if (host === 'localhost' || host === '127.0.0.1') {
-      return 'http://127.0.0.1:8787';
-    }
-  }
-
-  // Default production Worker URL
-  return 'https://daily-podcast-generator.jacoblbaum.workers.dev';
+  // Default to the GCP Gateway URL
+  return 'https://podcast-gw-clhumpgw.uc.gateway.dev';
 }
 
-export async function fetchAvailablePodcastTopics(): Promise<AvailablePodcast[]> {
-  const baseUrl = getWorkerBaseUrl();
-  const response = await fetch(`${baseUrl}/api/podcast-topics`);
+export async function fetchAvailablePodcastTopics(): Promise<string[]> {
+  const baseUrl = getGcpGatewayUrl();
+  const response = await fetch(`${baseUrl}/podcast_topics`);
   if (!response.ok) {
     throw new Error('Failed to fetch podcast topics');
   }
   return response.json();
+}
+
+export interface Podcast {
+  created_at: string;
+  id: string;
+  summary: string;
+  title: string;
+}
+
+export async function fetchPodcastsForTopic(topic: string): Promise<Podcast[]> {
+  const baseUrl = getGcpGatewayUrl();
+  const response = await fetch(`${baseUrl}/podcasts/${encodeURIComponent(topic)}`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch podcasts for topic');
+  }
+  const podcasts: Podcast[] = await response.json();
+  // Sort by most recent first (descending order by created_at)
+  return podcasts.sort((a, b) => 
+    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+}
+
+export interface PresignedUrlResponse {
+  url: string;
+}
+
+export async function fetchPresignedUrl(podcastId: string): Promise<string> {
+  const baseUrl = getGcpGatewayUrl();
+  const response = await fetch(`${baseUrl}/podcasts/audio/${encodeURIComponent(podcastId)}`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch presigned URL');
+  }
+  const data: PresignedUrlResponse = await response.json();
+  return data.url;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Topic page with per-topic podcast listings and updates routing and services to use GCP Gateway APIs with a direct playback flow.
> 
> - **Frontend**:
>   - **Routing**: Add `Route` for `'/topics/:topic'` in `src/App.tsx`.
>   - **Home**: Change topics to `string[]`; buttons navigate to `'/topics/{topic}'` (`src/components/HomePage.tsx`).
>   - **Topic Page**: New `src/components/TopicPage.tsx` with list of podcasts for a topic, fetching metadata, and navigating to `PodcastPage` with presigned audio URL; includes styles in `TopicPage.css`.
>   - **Podcast Playback**: `src/components/PodcastPage.tsx` supports `audioUrl`/`title` query params to play directly; falls back to existing search logic.
> - **Backend Service Integration**:
>   - Replace Worker URL with GCP Gateway (`VITE_GCP_FUNCTION_URL`) in `src/services/backend.ts`.
>   - New endpoints: `GET /podcast_topics`, `GET /podcasts/{topic}`, `GET /podcasts/audio/{id}`; add `fetchPodcastsForTopic`, `fetchPresignedUrl`; update `fetchAvailablePodcastTopics()` to return `string[]`.
> - **Docs**:
>   - Rename project to "Hark AI Front End" in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f71dd4091324b157fccb50184c7a5b9f29a97ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->